### PR TITLE
Modifying client_max_body_size to default to 128m to allow for larger files to be uploaded using WordPress, etc. Closes #30

### DIFF
--- a/rpm_buildtree/nginx-pkg-64/etc/nginx/nginx.conf
+++ b/rpm_buildtree/nginx-pkg-64/etc/nginx/nginx.conf
@@ -18,7 +18,7 @@ tcp_nodelay on;
 keepalive_timeout 65;
 types_hash_max_size 2048;
 server_tokens off;
-client_max_body_size 32m;
+client_max_body_size 128m;
 client_body_buffer_size    128k;
 
 #Tweak timeout settings below in case of a DOS attack


### PR DESCRIPTION
… files to be uploaded by default when using a CMS such as WordPress. Closes #30