### PR TITLE
cluster_dns_setup checks and verifies its not a subdomain before add/del

### DIFF
--- a/scripts/cluster_dns_setup.pl
+++ b/scripts/cluster_dns_setup.pl
@@ -71,8 +71,12 @@ sub adddns
    if ($address =~ $ip)
    {
     $dnsrec = $record->{name};
+    chop($dnsrec);
+    if ($dnsrec eq $domain)
+    {
     print "Ip is already set for $dnsrec\n";
     exit;
+    }
    }
   }
 
@@ -106,15 +110,21 @@ sub deldns
  my $address;
  my $line;
  my $found;
+ my $dnsrec;
   foreach my $record ( @{ $result->{result}[0]{record} } )
   {
    $address = $record->{address};
    if ($address =~ $ip)
    {
+    $dnsrec = $record->{name};
+    chop($dnsrec);
+    if ($dnsrec eq $domain)
+    {
     $line = $record->{Line};
     $found +=1;
+    }
    }
-  }
+ }
   if ($found)
   {
     $request = HTTP::Request->new( POST => "https://127.0.0.1:2087/json-api/removezonerecord?api.version=1&zone=$domain&line=$line");


### PR DESCRIPTION
Test case
A subdomain is hosted in the slave server.

Adding the A rec for the domain failed as earlier the checkes were if the ip is present. Same thing in deletion. It deleted the subdomain as it would be the first match.

Fixed this with some branching conditionals.