### PR TITLE
Add session cache to default SSL server so it is avaliable to all vhosts

### DIFF
--- a/rpm_buildtree/nginx-pkg-64-common/etc/nginx/conf.d/default_server.conf
+++ b/rpm_buildtree/nginx-pkg-64-common/etc/nginx/conf.d/default_server.conf
@@ -5,6 +5,8 @@ server {
         #CPMAIN6SSLCONF
         ssl_certificate CPANELCERTPATH;
         ssl_certificate_key CPANELCERTPATH;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout  5m;
         server_name _;
         access_log off;
         location / {


### PR DESCRIPTION
SSL session cache needs to be set in the default server otherwise it doesn't work for vhosts