### PR TITLE
Proxy all cPanel services to cpanel apache do correct checks

### DIFF
--- a/rpm_buildtree/nginx-pkg-64-common/etc/nginx/conf.d/cpanel_services.conf
+++ b/rpm_buildtree/nginx-pkg-64-common/etc/nginx/conf.d/cpanel_services.conf
@@ -1,55 +1,6 @@
 #Include all cpanel services called via port 80  or 443 here
-location /mailman/archives {
+location ~* /(controlpanel|cpanel|kpanel|securecontrolpanel|securecpanel|securewhm|webmail|whm|bandwidth|img-sys|java-sys|mailman/archives|pipermail|sys_cpanel|cgi-sys|mailman) {
         proxy_pass   http://CPANELIP:9999;
-        proxy_set_header   Host   $host;
-        proxy_set_header   X-Real-IP  $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /pipermail {
-        proxy_pass   http://CPANELIP:9999;
-        proxy_set_header   Host   $host;
-        proxy_set_header   X-Real-IP  $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /sys_cpanel {
-        proxy_pass   http://CPANELIP:9999;
-        proxy_set_header   Host   $host;
-        proxy_set_header   X-Real-IP  $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location  /cgi-sys {
-        proxy_pass   http://CPANELIP:9999;
-        proxy_set_header   Host   $host;
-        proxy_set_header   X-Real-IP  $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /mailman {
-	proxy_pass   http://CPANELIP:9999;
-        proxy_set_header   Host   $host;
-        proxy_set_header   X-Real-IP  $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /cpanel {
-        proxy_pass   http://CPANELIP:2082;
-        proxy_set_header   Host   $host;
-        proxy_set_header   X-Real-IP  $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /whm {
-        proxy_pass   http://CPANELIP:2086;
-        proxy_set_header   Host   $host;
-        proxy_set_header   X-Real-IP  $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /webmail {
-        proxy_pass   http://CPANELIP:2095;
         proxy_set_header   Host   $host;
         proxy_set_header   X-Real-IP  $remote_addr;
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/rpm_buildtree/nginx-pkg-64-common/etc/nginx/conf.d/cpanel_services.conf
+++ b/rpm_buildtree/nginx-pkg-64-common/etc/nginx/conf.d/cpanel_services.conf
@@ -1,5 +1,5 @@
 #Include all cpanel services called via port 80  or 443 here
-location ~* /(controlpanel|cpanel|kpanel|securecontrolpanel|securecpanel|securewhm|webmail|whm|bandwidth|img-sys|java-sys|mailman/archives|pipermail|sys_cpanel|cgi-sys|mailman) {
+location ~* ^/(controlpanel|cpanel|kpanel|securecontrolpanel|securecpanel|securewhm|webmail|whm|bandwidth|img-sys|java-sys|mailman/archives|pipermail|sys_cpanel|cgi-sys|mailman) {
         proxy_pass   http://CPANELIP:9999;
         proxy_set_header   Host   $host;
         proxy_set_header   X-Real-IP  $remote_addr;


### PR DESCRIPTION
When sending /whm or /webmail to port 2086 or 2095, the "/webmail" is maintained on the URL after login, resulting in a 404 error. This points all URLs back to cPanel Apache so that the cPanel redirect script runs and processes the URLs correctly, including the secure/non-secure preferences set in WHM Tweaks are honoured.

Also added additional locations as found in the cPanel httpd.conf to ensure that everything a user might be expecting to find on a cPanel server is working.