### PR TITLE
Added Drupal sitemap.xml directive, allowing to map it to the index.php.

### DIFF
--- a/conf/5016.j2
+++ b/conf/5016.j2
@@ -18,6 +18,10 @@ location ~ (^|/)\. {
 return 403;
 }
 
+location ~ /sitemap.xml {
+try_files $uri @rewrite;
+}
+
 location / {
 
 # Include NAXSI settings


### PR DESCRIPTION
Drupal 7 and 8 uses xmlsitemap module, which generates (and regularly updates) sitemap.xml file stored in Drupal public filesystem (defaults to sites/default/files/). This path may vary based on the public filesystem location or Drupal multisite installation.

By default xmlsitemap file is served from the top level URI as domain.com/sitemap.xml. In order for this file to display correctly, it has to be mapped to index.php, from there it will pull the right sitemap file based on website configuration.

This PR addresses the gap for any Drupal site currently returning 404 Not Found error when Nginx is set as the webserver proxying to PHP directly, bypassing Apache.

It has been tested on a Drupal 7 site https://www.euroupvcwindows.com.au/sitemap.xml

It is safe to merge into Drupal 7+ template