### PR TITLE
Added XML Sitemap support generated by YoastSEO Plugin for Wordpress.

### DIFF
--- a/conf/5001.j2
+++ b/conf/5001.j2
@@ -2,6 +2,8 @@
 root {{ DOCUMENTROOT }};
 index index.php index.html index.htm;
 
+include /etc/nginx/conf.d/yoast_seo_wordpress.conf;
+
 location / {
 
 # Include NAXSI settings

--- a/conf/5026.j2
+++ b/conf/5026.j2
@@ -3,6 +3,8 @@
 root {{ DOCUMENTROOT }};
 index index.php index.html index.htm;
 
+include /etc/nginx/conf.d/yoast_seo_wordpress.conf;
+
 location / {
 
 # Include NAXSI settings

--- a/conf/5028.j2
+++ b/conf/5028.j2
@@ -24,7 +24,7 @@ if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_lo
 set $cache_uri 'null cache';
 }
 
-
+include /etc/nginx/conf.d/yoast_seo_wordpress.conf;
 
 location / {
 

--- a/conf/5029.j2
+++ b/conf/5029.j2
@@ -23,6 +23,8 @@ if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_lo
 set $cache_uri 'null cache';
 }
 
+include /etc/nginx/conf.d/yoast_seo_wordpress.conf;
+
 location / {
 
 # Include NAXSI settings

--- a/conf/5030.j2
+++ b/conf/5030.j2
@@ -69,7 +69,7 @@ rewrite ^/wp-content/cache/minify/(.+/[X]+\.css)$ /wp-content/plugins/w3-total-c
 rewrite ^/wp-content/cache/minify/(.+\.(css|js))$ /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1 last;
 # END W3TC Minify core
 
-
+include /etc/nginx/conf.d/yoast_seo_wordpress.conf;
 
 location / {
 

--- a/conf/wpredis_auto.j2
+++ b/conf/wpredis_auto.j2
@@ -3,6 +3,8 @@
 root {{ DOCUMENTROOT }};
 index index.php index.html index.htm;
 
+include /etc/nginx/conf.d/yoast_seo_wordpress.conf;
+
 location / {
 
 # Include NAXSI settings

--- a/conf/wpredis_helper.j2
+++ b/conf/wpredis_helper.j2
@@ -3,6 +3,8 @@
 root {{ DOCUMENTROOT }};
 index index.php index.html index.htm;
 
+include /etc/nginx/conf.d/yoast_seo_wordpress.conf;
+
 location / {
 
 # Include NAXSI settings

--- a/conf/yoast_seo_wordpress.conf.j2
+++ b/conf/yoast_seo_wordpress.conf.j2
@@ -1,0 +1,17 @@
+#Yoast SEO Sitemaps
+location ~ ([^/]*)sitemap(.*).x(m|s)l$ {
+## this redirects sitemap.xml to /sitemap_index.xml
+rewrite ^/sitemap.xml$ /sitemap_index.xml permanent;
+## this makes the XML sitemaps work
+rewrite ^/([a-z]+)?-?sitemap.xsl$ /index.php?xsl=$1 last;
+rewrite ^/sitemap_index.xml$ /index.php?sitemap=1 last;
+rewrite ^/([^/]+?)-sitemap([0-9]+)?.xml$ /index.php?sitemap=$1&sitemap_n=$2 last;
+## The following lines are optional for the premium extensions
+## News SEO
+rewrite ^/news-sitemap.xml$ /index.php?sitemap=wpseo_news last;
+## Local SEO
+rewrite ^/locations.kml$ /index.php?sitemap=wpseo_local_kml last;
+rewrite ^/geo-sitemap.xml$ /index.php?sitemap=wpseo_local last;
+## Video SEO
+rewrite ^/video-sitemap.xsl$ /index.php?xsl=video last;
+}

--- a/rpm_buildtree/nDeploy-cluster-slave_build_script.sh
+++ b/rpm_buildtree/nDeploy-cluster-slave_build_script.sh
@@ -6,12 +6,12 @@ RPM_ITERATION="5"
 
 rm -f nDeploy-cluster-slave-pkg-centos7/nDeploy-*
 rsync -av ../scripts/generate_default_vhost_config.py ../scripts/postfix_backupmx_setup.sh ../scripts/postfix_backupmx_update.sh ../scripts/easy_php_setup.sh ../scripts/easy_hhvm_setup.sh ../scripts/*ghost_hunter* ../scripts/init_backends.py ../scripts/update_backend.py nDeploy-cluster-slave-pkg-centos7/opt/nDeploy/scripts/
-rsync -av ../conf/php-fpm* ../conf/cpanel_services.conf.j2 ../conf/default_server.conf.j2 ../conf/hhvm* ../conf/httpd_mod_remoteip.include.j2 ../conf/secure-php-fpm* nDeploy-cluster-slave-pkg-centos7/opt/nDeploy/conf/
+rsync -av ../conf/php-fpm* ../conf/cpanel_services.conf.j2 ../conf/yoast_seo_wordpress.conf.j2 ../conf/default_server.conf.j2 ../conf/hhvm* ../conf/httpd_mod_remoteip.include.j2 ../conf/secure-php-fpm* nDeploy-cluster-slave-pkg-centos7/opt/nDeploy/conf/
 rsync -av nDeploy-pkg-centos7/usr/lib/systemd/system/ndeploy_backends.service  nDeploy-cluster-slave-pkg-centos7/usr/lib/systemd/system/ndeploy_backends.service
 
 rm -f nDeploy-cluster-slave-pkg/nDeploy-*
 rsync -av ../scripts/generate_default_vhost_config.py ../scripts/postfix_backupmx_setup.sh ../scripts/postfix_backupmx_update.sh ../scripts/easy_php_setup.sh ../scripts/easy_hhvm_setup.sh ../scripts/*ghost_hunter* ../scripts/init_backends.py ../scripts/update_backend.py nDeploy-cluster-slave-pkg/opt/nDeploy/scripts/
-rsync -av ../conf/php-fpm* ../conf/cpanel_services.conf.j2 ../conf/default_server.conf.j2 ../conf/hhvm* ../conf/httpd_mod_remoteip.include.j2 ../conf/secure-php-fpm* nDeploy-cluster-slave-pkg/opt/nDeploy/conf/
+rsync -av ../conf/php-fpm* ../conf/cpanel_services.conf.j2 ../conf/yoast_seo_wordpress.conf.j2 ../conf/default_server.conf.j2 ../conf/hhvm* ../conf/httpd_mod_remoteip.include.j2 ../conf/secure-php-fpm* nDeploy-cluster-slave-pkg/opt/nDeploy/conf/
 rsync -av nDeploy-pkg/etc/rc.d/init.d/ndeploy_backends nDeploy-cluster-slave-pkg/etc/rc.d/init.d/ndeploy_backends
 
 cd nDeploy-cluster-slave-pkg-centos7

--- a/scripts/generate_default_vhost_config.py
+++ b/scripts/generate_default_vhost_config.py
@@ -52,3 +52,8 @@ httpd_mod_remoteip_template = templateEnv.get_template('httpd_mod_remoteip.inclu
 httpd_mod_remoteip_config = httpd_mod_remoteip_template.render(templateVars)
 with codecs.open('/etc/nginx/conf.d/httpd_mod_remoteip.include', 'w', 'utf-8') as httpd_mod_remoteip_config_file:
     httpd_mod_remoteip_config_file.write(httpd_mod_remoteip_config)
+# Generate yoast_seo_wordpress.conf
+yoast_seo_wordpress_template = templateEnv.get_template('yoast_seo_wordpress.conf.j2')
+yoast_seo_wordpress_config = yoast_seo_wordpress_template.render(templateVars)
+with codecs.open('/etc/nginx/conf.d/yoast_seo_wordpress.conf', 'w', 'utf-8') as yoast_seo_wordpress_config_file:
+    yoast_seo_wordpress_config_file.write(yoast_seo_wordpress_config)


### PR DESCRIPTION
XML Sitemap support in Nginx is not working out of the box with Nginx, since Nginx is trying to load the file sitemap_index.xml directly and cannot find it. In Wordpress, such file should be redirected to index.php, however this PR adds support to YoastSEO rewrite rules for Nginx taken from https://kb.yoast.com/kb/xml-sitemaps-nginx/

It is possible to extend the functionality of this plugin by making YoastSEO a checkbox and load it optionally based on the end user choice