### PR TITLE
Upgrade Status supports Term

### DIFF
--- a/nDeploy_whm/easy_netdata_setup.cgi
+++ b/nDeploy_whm/easy_netdata_setup.cgi
@@ -41,7 +41,7 @@ if form.getvalue('run_installer') == 'enabled':
         procExe = subprocess.Popen('echo "*** Netdata has been reinstalled using existing credentials ***" >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         procExe.wait()
         
-        commoninclude.print_success('Netdata reinstalled!')        
+        commoninclude.print_success('Netdata reinstalled!')
         
     elif form.getvalue('netdata_pass') != None:
 
@@ -52,7 +52,7 @@ if form.getvalue('run_installer') == 'enabled':
         procExe = subprocess.Popen('echo "*** Netdata has been reinstalled using existing the new credentials ***" >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         procExe.wait()
         
-        commoninclude.print_success('Netdata installed!')        
+        commoninclude.print_success('Netdata installed!')
 
     else:
         commoninclude.print_warning('Try again with credentials!')

--- a/nDeploy_whm/upgrade_control.cgi
+++ b/nDeploy_whm/upgrade_control.cgi
@@ -34,7 +34,7 @@ print('    <body>')
 
 if form.getvalue('upgrade_control'):
 
-    if True:#form.getvalue('upgrade_control') == 'check':
+    if form.getvalue('upgrade_control') == 'check':
 
         procExe = subprocess.Popen('echo -e "Checking for updates..." > '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         procExe.wait()
@@ -58,26 +58,41 @@ if form.getvalue('upgrade_control'):
 
     elif form.getvalue('upgrade_control') == 'reinstall':
         if os.path.isfile(cluster_config_file):
-            procExe = subprocess.Popen('yum -y --enablerepo=ndeploy reinstall *nDeploy* && ansible -i /opt/nDeploy/conf/nDeploy-cluster/hosts ndeployslaves -m shell -a \"yum -y --enablerepo=ndeploy reinstall *nDeploy*\"', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+            procExe = subprocess.Popen('echo -e "Reinstalling application cluster-wide..." > '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            procExe.wait()
+            procExe = subprocess.Popen('yum -y --enablerepo=ndeploy reinstall *nDeploy* && ansible -i /opt/nDeploy/conf/nDeploy-cluster/hosts ndeployslaves -m shell -a \"yum -y --enablerepo=ndeploy reinstall *nDeploy*\" >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            procExe.wait()
+
+            commoninclude.print_warning('Application has been reinstalled cluster-wide!')
+
         else:
-            procExe = subprocess.Popen('yum -y --enablerepo=ndeploy reinstall *nDeploy*', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        print('<ul class="shelloutput">')
-        print('    <li><b>Reinstalling Application:</b></li>')
+
+            procExe = subprocess.Popen('echo -e "Reinstalling application..." > '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            procExe.wait()
+            procExe = subprocess.Popen('yum -y --enablerepo=ndeploy reinstall *nDeploy* >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            procExe.wait()
+
+            commoninclude.print_warning('Application has been reinstalled!')
+
     elif form.getvalue('upgrade_control') == 'upgrade':
         if os.path.isfile(cluster_config_file):
-            procExe = subprocess.Popen('yum -y --enablerepo=ndeploy upgrade *nDeploy* && ansible -i /opt/nDeploy/conf/nDeploy-cluster/hosts ndeployslaves -m shell -a \"yum -y --enablerepo=ndeploy upgrade *nDeploy*\" && '+installation_path+'/scripts/attempt_autofix.sh', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        else:
-            procExe = subprocess.Popen('yum -y --enablerepo=ndeploy upgrade *nDeploy* && '+installation_path+'/scripts/attempt_autofix.sh && nginx -t && needs-restarting | grep nginx && service nginx restart', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        print('<ul class="shelloutput">')
-        print('    <li><b>Upgrading Application:</b></li>')
 
-    if form.getvalue('upgrade_control') == 'reinstall' or form.getvalue('upgrade_control') == 'upgrade':
-        print('    <li>&nbsp;</li>')
-        for line in iter(procExe.stdout.readline, b''):
-            print('    <li>'+line.rstrip()+'</li>')
-        print('    <li>&nbsp;</li>')
-        print('    <li><b>Application maintenance completed!</b></li>')
-        print('</ul>')
+            procExe = subprocess.Popen('echo -e "Upgrading application cluster-wide..." > '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            procExe.wait()
+            procExe = subprocess.Popen('yum -y --enablerepo=ndeploy upgrade *nDeploy* && ansible -i /opt/nDeploy/conf/nDeploy-cluster/hosts ndeployslaves -m shell -a \"yum -y --enablerepo=ndeploy upgrade *nDeploy*\" && '+installation_path+'/scripts/attempt_autofix.sh >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            procExe.wait()
+
+            commoninclude.print_warning('Application has been upgraded cluster-wide!')
+
+        else:
+
+            procExe = subprocess.Popen('echo -e "Upgrading application..." > '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            procExe.wait()
+            procExe = subprocess.Popen('yum -y --enablerepo=ndeploy upgrade *nDeploy* && '+installation_path+'/scripts/attempt_autofix.sh && nginx -t && needs-restarting | grep nginx && service nginx restart >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            procExe.wait()
+
+            commoninclude.print_warning('Application has been upgraded!')
 
 else:
     commoninclude.print_forbidden()

--- a/nDeploy_whm/upgrade_control.cgi
+++ b/nDeploy_whm/upgrade_control.cgi
@@ -18,6 +18,8 @@ __status__ = "Development"
 
 installation_path = "/opt/nDeploy"  # Absolute Installation Path
 cluster_config_file = installation_path+"/conf/ndeploy_cluster.yaml"
+whm_terminal_log = installation_path+"/nDeploy_whm/term.log"
+update_status_file = installation_path+"/conf/NDEPLOY_UPGRADE_STATUS"
 
 cgitb.enable()
 
@@ -26,15 +28,34 @@ form = cgi.FieldStorage()
 print('Content-Type: text/html')
 print('')
 print('<html>')
-print('<head>')
-print('</head>')
-print('<body>')
+print('    <head>')
+print('    </head>')
+print('    <body>')
 
 if form.getvalue('upgrade_control'):
 
-    if form.getvalue('upgrade_control') == 'check':
-        subprocess.Popen(installation_path+'/scripts/check_for_updates.sh', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        print('Checking for updates!')
+    if True:#form.getvalue('upgrade_control') == 'check':
+
+        procExe = subprocess.Popen('echo -e "Checking for updates..." > '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        procExe.wait()
+        procExe = subprocess.Popen(installation_path+'/scripts/check_for_updates.sh >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        procExe.wait()
+
+        # Get upgrade status of nDeploy
+        update_status = ''
+        if os.path.isfile(update_status_file):
+            with open(update_status_file, 'r') as update_status_value:
+                update_status = update_status_value.read(1)
+
+        if update_status == '0':
+            commoninclude.print_success('You are up to date!')
+        
+        elif update_status == '1':
+            commoninclude.print_success('Upgrades Available!')
+        
+        else:
+            commoninclude.print_warning('Issue checking for updates!')
+
     elif form.getvalue('upgrade_control') == 'reinstall':
         if os.path.isfile(cluster_config_file):
             procExe = subprocess.Popen('yum -y --enablerepo=ndeploy reinstall *nDeploy* && ansible -i /opt/nDeploy/conf/nDeploy-cluster/hosts ndeployslaves -m shell -a \"yum -y --enablerepo=ndeploy reinstall *nDeploy*\"', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -59,7 +80,7 @@ if form.getvalue('upgrade_control'):
         print('</ul>')
 
 else:
-    print('Forbidden::Mising Upgrade Control Data')
+    commoninclude.print_forbidden()
 
-print('</body>')
+print('    </body>')
 print('</html>')

--- a/nDeploy_whm/upgrade_control.cgi
+++ b/nDeploy_whm/upgrade_control.cgi
@@ -64,7 +64,7 @@ if form.getvalue('upgrade_control'):
             procExe = subprocess.Popen('yum -y --enablerepo=ndeploy reinstall *nDeploy* && ansible -i /opt/nDeploy/conf/nDeploy-cluster/hosts ndeployslaves -m shell -a \"yum -y --enablerepo=ndeploy reinstall *nDeploy*\" >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             procExe.wait()
 
-            commoninclude.print_warning('Application has been reinstalled cluster-wide!')
+            commoninclude.print_success('Application has been reinstalled cluster-wide!')
 
         else:
 
@@ -73,7 +73,7 @@ if form.getvalue('upgrade_control'):
             procExe = subprocess.Popen('yum -y --enablerepo=ndeploy reinstall *nDeploy* >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             procExe.wait()
 
-            commoninclude.print_warning('Application has been reinstalled!')
+            commoninclude.print_success('Application has been reinstalled!')
 
     elif form.getvalue('upgrade_control') == 'upgrade':
         if os.path.isfile(cluster_config_file):
@@ -83,7 +83,7 @@ if form.getvalue('upgrade_control'):
             procExe = subprocess.Popen('yum -y --enablerepo=ndeploy upgrade *nDeploy* && ansible -i /opt/nDeploy/conf/nDeploy-cluster/hosts ndeployslaves -m shell -a \"yum -y --enablerepo=ndeploy upgrade *nDeploy*\" && '+installation_path+'/scripts/attempt_autofix.sh >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             procExe.wait()
 
-            commoninclude.print_warning('Application has been upgraded cluster-wide!')
+            commoninclude.print_success('Application has been upgraded cluster-wide!')
 
         else:
 
@@ -92,7 +92,7 @@ if form.getvalue('upgrade_control'):
             procExe = subprocess.Popen('yum -y --enablerepo=ndeploy upgrade *nDeploy* && '+installation_path+'/scripts/attempt_autofix.sh && nginx -t && needs-restarting | grep nginx && service nginx restart >> '+whm_terminal_log, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             procExe.wait()
 
-            commoninclude.print_warning('Application has been upgraded!')
+            commoninclude.print_success('Application has been upgraded!')
 
 else:
     commoninclude.print_forbidden()

--- a/scripts/check_for_updates.sh
+++ b/scripts/check_for_updates.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-yum --enablerepo=ndeploy check-update *nDeploy*
+yum --enablerepo=ndeploy check-update nDeploy*
 
 if [ $? == 100 ]; then
     echo "1" > /opt/nDeploy/conf/NDEPLOY_UPGRADE_STATUS
-    echo "You've got nDeploy updates available!"
+    echo "Upgrades available!"
 else
     echo "0" > /opt/nDeploy/conf/NDEPLOY_UPGRADE_STATUS
-    echo "No nDeploy updates detected..."
+    echo "You are up to date!"
 fi


### PR DESCRIPTION
- Reinstall, Upgrade, and Check for Upgrade now supports Term
- Check update reports back status via Toast.

_Granted this will be in cron, it might be a good idea to setup a dual button for this so we can always check for updates (between crons) and fire either Upgrade or Reinstall depending on status. (All from same widget)_