### PR TITLE
Nemesida WAF module install/uninstall support added to nDeploy Control

### DIFF
--- a/nDeploy_whm/module_installer.cgi
+++ b/nDeploy_whm/module_installer.cgi
@@ -25,7 +25,7 @@ form = cgi.FieldStorage()
 
 print_simple_header()
 
-if form.getvalue('test_cookie') and form.getvalue('geoip2') and form.getvalue('passenger'):
+if form.getvalue('test_cookie') and form.getvalue('geoip2') and form.getvalue('passenger') and form.getvalue('waf'):
     cmd_install = ""
     cmd_uninstall = ""
     if form.getvalue('test_cookie') == 'enabled' and not os.path.isfile('/etc/nginx/modules.d/testcookie_access.load'):
@@ -40,6 +40,10 @@ if form.getvalue('test_cookie') and form.getvalue('geoip2') and form.getvalue('p
         cmd_install += "nginx-nDeploy-module-passenger "
     elif form.getvalue('passenger') == 'disabled' and os.path.isfile('/etc/nginx/modules.d/passenger.load'):
         cmd_uninstall += "nginx-nDeploy-module-passenger "
+    if form.getvalue('waf') == 'enabled' and not os.path.isfile('/etc/nginx/modules.d/nemesida.load'):
+        cmd_install += "nginx-nDeploy-module-nemesida "
+    elif form.getvalue('waf') == 'disabled' and os.path.isfile('/etc/nginx/modules.d/nemesida.load'):
+        cmd_uninstall += "nginx-nDeploy-module-nemesida "
     if cmd_install != "" or cmd_uninstall != "":
         if cmd_install == "" and cmd_uninstall != "":
             if os.path.isfile(cluster_config_file):

--- a/nDeploy_whm/ndeploy_control.cgi
+++ b/nDeploy_whm/ndeploy_control.cgi
@@ -728,6 +728,7 @@ test_cookie_hint = " Controls loading of nginx-nDeploy-module-testcookie_access 
 # brotli_hint = " Controls loading of nginx-nDeploy-module-brotli which is a newer bandwidth optimization created by Google. "
 geoip2_hint = " Controls loading of nginx-nDeploy-module-geoip2 which creates variables based on the client IP address. "
 passenger_hint = " Controls loading of nginx-nDeploy-module-passenger which installs Phusion Passenger web application server. "
+waf_hint = " Controls loading of nginx-nDeploy-module-nemesida which installs the Nemesida web application firewall. "
 
 print('                            <div class="card-body"> <!-- Card Body Start -->')
 print('                                <div class="row row-btn-group-toggle"> <!-- Row Start -->')
@@ -848,6 +849,26 @@ else:
     print('                                        </label>')
     print('                                        <label class="btn btn-light active">')
     print('                                            <input type="radio" name="passenger" value="disabled" autocomplete="off" checked> Uninstalled')
+    print('                                        </label>')
+print('                                        </div>')
+print('                                    </div>')
+
+print(('                                    '+return_label("Nemesida WAF Module", waf_hint)))
+print('                                    <div class="col-md-6">')
+print('                                        <div class="btn-group btn-block btn-group-toggle" data-toggle="buttons">')
+if os.path.isfile('/etc/nginx/modules.d/nemesida.load'):
+    print('                                        <label class="btn btn-light active">')
+    print('                                            <input type="radio" name="waf" value="enabled" autocomplete="off" checked> Installed')
+    print('                                        </label>')
+    print('                                        <label class="btn btn-light">')
+    print('                                            <input type="radio" name="waf" value="disabled" autocomplete="off"> Uninstalled')
+    print('                                        </label>')
+else:
+    print('                                        <label class="btn btn-light">')
+    print('                                            <input type="radio" name="waf" value="enabled" autocomplete="off"> Installed')
+    print('                                        </label>')
+    print('                                        <label class="btn btn-light active">')
+    print('                                            <input type="radio" name="waf" value="disabled" autocomplete="off" checked> Uninstalled')
     print('                                        </label>')
 print('                                        </div>')
 print('                                    </div>')


### PR DESCRIPTION
- Install/Uninstall added.
- Need to add easy_nemesida_waf_setup.sh either to RPM or will add a separate call to module_installer.cgi