### PR TITLE
Fix 421 Misdirected Request by adding proxy_ssl_server_name

### DIFF
--- a/conf/server.j2
+++ b/conf/server.j2
@@ -17,6 +17,8 @@ ssl_certificate_key {{ CPANELSSLCRT }};
 {% if OCSPSTAPLE %}
 ssl_stapling on;
 {% endif %}
+proxy_ssl_server_name on;
+proxy_ssl_name $host;
 {% endif %}
 server_name www.{{ MAINDOMAINNAME }};
 
@@ -91,6 +93,8 @@ ssl_certificate_key {{ CPANELSSLCRT }};
 {% if OCSPSTAPLE %}
 ssl_stapling on;
 {% endif %}
+proxy_ssl_server_name on;
+proxy_ssl_name $host;
 {% endif %}
 server_name {{ MAINDOMAINNAME }};
 
@@ -165,6 +169,8 @@ ssl_certificate_key {{ CPANELSSLCRT }};
 {% if OCSPSTAPLE %}
 ssl_stapling on;
 {% endif %}
+proxy_ssl_server_name on;
+proxy_ssl_name $host;
 {% endif %}
 server_name {% for DOMAIN in REDIRECTALIASES_LIST %}{{ DOMAIN+" " }}{% endfor %};
 
@@ -394,6 +400,8 @@ ssl_certificate_key {{ CPANELSSLCRT }};
 {% if OCSPSTAPLE %}
 ssl_stapling on;
 {% endif %}
+proxy_ssl_server_name on;
+proxy_ssl_name $host;
 server_name  {% for DOMAIN in DOMAINLIST %}{{ DOMAIN+" " }}{% endfor %};
 {% if waf == 'enabled' %}
 error_log {{ HOMEDIR }}/logs/nginx_error_log;
@@ -545,6 +553,8 @@ ssl_certificate_key {{ CPANELSSLCRT }};
 {% if OCSPSTAPLE %}
 ssl_stapling on;
 {% endif %}
+proxy_ssl_server_name on;
+proxy_ssl_name $host;
 {% endif %}
 server_name {% for DOMAIN in DOMAINLIST_PROXY_SUBDOMAIN %}{{ "cpanel."+DOMAIN+" " }}{% endfor %} {% for DOMAIN in DOMAINLIST_PROXY_SUBDOMAIN %}{{ "webmail."+DOMAIN+" " }}{% endfor %} {% for DOMAIN in DOMAINLIST_PROXY_SUBDOMAIN %}{{ "whm."+DOMAIN+" " }}{% endfor %} {% for DOMAIN in DOMAINLIST_PROXY_SUBDOMAIN %}{{ "cpcontacts."+DOMAIN+" " }}{% endfor %} {% for DOMAIN in DOMAINLIST %}{{ "cpcalendars."+DOMAIN+" " }}{% endfor %};
 location / {


### PR DESCRIPTION
Problem
Sites intermittently return HTTP 421 "Misdirected Request" errors after failover/failback events. The error occurs on HTTPS requests and affects all clients.

Root Cause
When nginx proxies HTTPS requests to Apache on port 4430, it does not send the SNI (Server Name Indication) header. Apache has multiple SSL vhosts listening on port 4430 and relies on SNI to determine which vhost should handle the request. Without SNI, Apache cannot match the incoming request to the correct vhost and returns a 421 error.

The 421 response includes charset=iso-8859-1 indicating it originates from Apache, not nginx.

Solution
Add the following nginx directives to all SSL server blocks in conf/server.j2:

nginxproxy_ssl_server_name on;
proxy_ssl_name $host;

These directives instruct nginx to:

proxy_ssl_server_name on - Enable passing the SNI header when proxying to upstream SSL servers proxy_ssl_name $host - Use the requested hostname as the SNI value


Files Changed

conf/server.j2 - Added proxy SSL settings in all 5 SSL server blocks (after ssl_stapling on; directives)

Testing

Before fix: curl -Ik https://example.com returns HTTP 421
After fix: curl -Ik https://example.com returns HTTP 200